### PR TITLE
ci: autoclose stale issues

### DIFF
--- a/.github/workflows/stale-cron.yaml
+++ b/.github/workflows/stale-cron.yaml
@@ -1,0 +1,29 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 30
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          exempt-issue-labels: "bug, enhancement"
+          stale-issue-label: stale
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has
+            not had recent activity. It will be closed if no further activity
+            occurs. Thank you for your contributions.
+          close-issue-message: >
+            This issue was closed because it has been inactive for 30 days
+            since being marked as stale.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # maas-github-workflows
-Reusable GitHub Workflows used by MAAS
+[Reusable GitHub Workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows) used by MAAS
+
+
+You can embed them in a workflow you run at the job level.
+


### PR DESCRIPTION
Mark issue as stale if there is no activity for 30 days. Close stale issues after 30 days of inactivity.

This doesn't affect issues with labels: `bug` or `enhancement`.